### PR TITLE
Fix swipe detection when touch starts at 0

### DIFF
--- a/hooks/use-swipe.ts
+++ b/hooks/use-swipe.ts
@@ -14,7 +14,7 @@ export const useSwipe = (onSwipeLeft: () => void, onSwipeRight: () => void) => {
   const onTouchMove = (e: React.TouchEvent) => setTouchEnd(e.targetTouches[0].clientX);
 
   const onTouchEnd = useCallback(() => {
-    if (!touchStart || !touchEnd) return;
+    if (touchStart === null || touchEnd === null) return;
     const distance = touchStart - touchEnd;
     const isLeftSwipe = distance > minSwipeDistance;
     const isRightSwipe = distance < -minSwipeDistance;


### PR DESCRIPTION
## Summary
- handle zero-valued coordinates in swipe hook

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68412e32898c83308abe5cfdff4bd098