### PR TITLE
Fix timeline last entry activation

### DIFF
--- a/components/ui/timeline.tsx
+++ b/components/ui/timeline.tsx
@@ -45,10 +45,11 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
   useMotionValueEvent(scrollYProgress, "change", (latest) => {
     // Skip animation updates if in an inactive modal
     if (inModal && !isModalActive) return;
-    
+
     const threshold = 1 / data.length;
-    const newIndex = Math.floor(latest / threshold);
-    if (newIndex >= 0 && newIndex < data.length) {
+    const centeredIndex = Math.floor((latest + threshold / 2) / threshold);
+    const newIndex = Math.min(centeredIndex, data.length - 1);
+    if (newIndex >= 0) {
       setActiveIndex(newIndex);
     }
   });


### PR DESCRIPTION
## Summary
- fix timeline scroll event logic so last entry becomes active when scrolled to bottom

## Testing
- `npx next lint` *(fails: Need to install next)*

------
https://chatgpt.com/codex/tasks/task_e_68413eafc0e483309e3a287d1a876503