### PR TITLE
Fix timeline animation and mobile dots

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,5 @@
     "semi": false,
     "proseWrap": "always",
     "printWidth": 80,
-    "plugins": ["prettier-plugin-tailwindess"]
+    "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/components/ui/timeline.tsx
+++ b/components/ui/timeline.tsx
@@ -3,6 +3,7 @@ import {
   useMotionValueEvent,
   useScroll,
   useTransform,
+  useSpring,
   motion,
 } from "framer-motion";
 import React, { useEffect, useRef, useState } from "react";
@@ -25,37 +26,57 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
   const inModal = modalContext?.isInsideModal ?? false;
   const isModalActive = modalContext?.isActive ?? false;
 
-  // Calculate accurate height based on content
+  // Calculate accurate height based on content and observe changes
   useEffect(() => {
-    if (ref.current) {
-      const rect = ref.current.getBoundingClientRect();
+    if (!ref.current) return;
+
+    const updateHeight = () => {
+      const rect = ref.current!.getBoundingClientRect();
       setHeight(rect.height);
-    }
-  }, [ref]);
+    };
+
+    updateHeight();
+
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(ref.current);
+    window.addEventListener("resize", updateHeight);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", updateHeight);
+    };
+  }, []);
   
   // Use different scroll offsets based on modal state
   const { scrollYProgress } = useScroll({
     target: containerRef,
-    offset: inModal 
-      ? ["start start", "end start"] // More aggressive offset for modal
-      : ["start 30%", "end 50%"],    // Original offset for regular page
+    offset: inModal
+      ? ["start start", "end end"] // Ensure full progress inside modal
+      : ["start 30%", "end end"],   // Reach 1 when bottom hits viewport end
+  });
+
+  // Smooth out progress for animations
+  const smoothProgress = useSpring(scrollYProgress, {
+    stiffness: 80,
+    damping: 20,
   });
 
   // Handle scroll animation differently based on modal context
-  useMotionValueEvent(scrollYProgress, "change", (latest) => {
+  useMotionValueEvent(smoothProgress, "change", (latest) => {
     // Skip animation updates if in an inactive modal
     if (inModal && !isModalActive) return;
-    
+
     const threshold = 1 / data.length;
-    const newIndex = Math.floor(latest / threshold);
-    if (newIndex >= 0 && newIndex < data.length) {
+    const centeredIndex = Math.floor((latest + threshold / 2) / threshold);
+    const newIndex = Math.min(centeredIndex, data.length - 1);
+    if (newIndex >= 0) {
       setActiveIndex(newIndex);
     }
   });
   
   // Animation transforms
-  const heightTransform = useTransform(scrollYProgress, [0, 1], [0, height]);
-  const opacityTransform = useTransform(scrollYProgress, [0, 0.1], [0, 1]);
+  const heightTransform = useTransform(smoothProgress, [0, 0.99], [0, height]);
+  const opacityTransform = useTransform(smoothProgress, [0, 0.1], [0, 1]);
 
   return (
     <div 
@@ -97,7 +118,7 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
             }}
             transition={{ duration: 0.5 }}
           >
-            <div className="sticky flex flex-col items-start top-32 self-start z-10">
+            <div className="sticky flex flex-col items-start top-24 md:top-32 self-start z-10">
               {/* Dot indicator with original size */}
               <motion.div 
                 className="h-2 w-2 absolute left-0 top-2 rounded-full bg-black dark:bg-white z-20"

--- a/components/ui/timeline.tsx
+++ b/components/ui/timeline.tsx
@@ -16,8 +16,8 @@ interface TimelineEntry {
 }
 
 export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
-  const ref = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState(0);
   const [activeIndex, setActiveIndex] = useState(0); // Default to first item as active
   
@@ -28,17 +28,17 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
 
   // Calculate accurate height based on content and observe changes
   useEffect(() => {
-    if (!ref.current) return;
+    if (!containerRef.current) return;
 
     const updateHeight = () => {
-      const rect = ref.current!.getBoundingClientRect();
+      const rect = containerRef.current!.getBoundingClientRect();
       setHeight(rect.height);
     };
 
     updateHeight();
 
     const resizeObserver = new ResizeObserver(updateHeight);
-    resizeObserver.observe(ref.current);
+    resizeObserver.observe(containerRef.current);
     window.addEventListener("resize", updateHeight);
 
     return () => {
@@ -67,7 +67,7 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
     if (inModal && !isModalActive) return;
 
     const threshold = 1 / data.length;
-    const CENTERING_OFFSET = threshold / 2; // Offset to center the active index calculation
+      <div ref={contentRef} className="relative max-w-7xl mx-auto">
     const centeredIndex = Math.floor((latest + CENTERING_OFFSET) / threshold);
     const newIndex = Math.min(centeredIndex, data.length - 1);
     if (newIndex >= 0) {

--- a/components/ui/timeline.tsx
+++ b/components/ui/timeline.tsx
@@ -67,7 +67,8 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
     if (inModal && !isModalActive) return;
 
     const threshold = 1 / data.length;
-    const centeredIndex = Math.floor((latest + threshold / 2) / threshold);
+    const CENTERING_OFFSET = threshold / 2; // Offset to center the active index calculation
+    const centeredIndex = Math.floor((latest + CENTERING_OFFSET) / threshold);
     const newIndex = Math.min(centeredIndex, data.length - 1);
     if (newIndex >= 0) {
       setActiveIndex(newIndex);
@@ -75,7 +76,7 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
   });
   
   // Animation transforms
-  const heightTransform = useTransform(smoothProgress, [0, 0.99], [0, height]);
+  const heightTransform = useTransform(smoothProgress, [0, 1], [0, height]);
   const opacityTransform = useTransform(smoothProgress, [0, 0.1], [0, 1]);
 
   return (

--- a/components/ui/timeline.tsx
+++ b/components/ui/timeline.tsx
@@ -28,17 +28,17 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
 
   // Calculate accurate height based on content and observe changes
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!contentRef.current) return;
 
     const updateHeight = () => {
-      const rect = containerRef.current!.getBoundingClientRect();
+      const rect = contentRef.current!.getBoundingClientRect();
       setHeight(rect.height);
     };
 
     updateHeight();
 
     const resizeObserver = new ResizeObserver(updateHeight);
-    resizeObserver.observe(containerRef.current);
+    resizeObserver.observe(contentRef.current);
     window.addEventListener("resize", updateHeight);
 
     return () => {
@@ -130,7 +130,7 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
                 transition={{ duration: 0.3 }}
               />
             </div>
-            <div className="relative pl-6 w-full">
+};
               <div className="mb-3">
                 <h3 className="text-lg font-medium text-foreground">
                   {item.title}


### PR DESCRIPTION
## Summary
- refine timeline height updates with ResizeObserver
- smooth scroll progress and ensure it reaches the end
- update transforms and sticky offset for mobile dots

## Testing
- `npx next lint` *(fails: Need to install next)*

------
https://chatgpt.com/codex/tasks/task_e_68413eafc0e483309e3a287d1a876503