### PR TITLE
Fix horizontal scrolling bug on mobile carousel

### DIFF
--- a/components/projects/mobileProjectCards.tsx
+++ b/components/projects/mobileProjectCards.tsx
@@ -81,10 +81,10 @@ const MobileProjectCards: React.FC<MobileProjectCardsProps> = ({ projects }) => 
   const prevProject = projects[(currentIndex - 1 + projects.length) % projects.length]
 
   return (
-    <div className="w-full relative">
+    <div className="w-full relative overflow-x-hidden">
       {/* Card Container */}
-      <div 
-        className="relative h-auto"
+      <div
+        className="relative h-auto overflow-x-hidden"
         onTouchStart={onTouchStart}
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}


### PR DESCRIPTION
## Summary
- prevent horizontal overflow in `MobileProjectCards`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684373f0c8608330a2170cbb861a0d64