### PR TITLE
Improve timeline interaction

### DIFF
--- a/components/ui/timeline.tsx
+++ b/components/ui/timeline.tsx
@@ -55,12 +55,16 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
   });
   
   // Animation transforms
-  const heightTransform = useTransform(scrollYProgress, [0, 1], [0, height]);
+  const heightTransform = useTransform(
+    scrollYProgress,
+    (latest) => (activeIndex === data.length - 1 ? height : latest * height),
+    [height, activeIndex]
+  );
   const opacityTransform = useTransform(scrollYProgress, [0, 0.1], [0, 1]);
 
   return (
     <div 
-      className={`${inModal ? "relative z-[500]" : ""} w-full pb-24`} 
+      className={`${inModal ? "relative z-[500]" : ""} w-full pb-40`}
       ref={containerRef}
     >
       <div className="max-w-7xl mx-auto">
@@ -72,11 +76,7 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
           style={{
             height: `${height}px`,
           }}
-          className={`absolute left-1 top-0 overflow-hidden w-[1px] ${
-            inModal 
-              ? "bg-neutral-200 dark:bg-neutral-700" 
-              : "bg-[linear-gradient(to_bottom,var(--tw-gradient-stops))] from-transparent from-[5%] via-neutral-200 dark:via-neutral-700 to-transparent to-[95%] [mask-image:linear-gradient(to_bottom,transparent_5%,black_15%,black_85%,transparent_95%)]"
-          } z-0`}
+          className="absolute left-1 top-0 overflow-hidden w-[1px] bg-neutral-200 dark:bg-neutral-700 z-0"
         >
           <motion.div
             style={{ 
@@ -88,11 +88,11 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
         </div>
         
         {data.map((item, index) => (
-          <motion.div 
-            key={index} 
-            className="flex mb-12"
+          <motion.div
+            key={index}
+            className="flex mb-16"
             initial={{ opacity: 0.4 }}
-            animate={{ 
+            animate={{
               opacity: inModal ? 1 : (activeIndex === index ? 1 : 0.4),
               scale: 1
             }}
@@ -100,9 +100,9 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
           >
             <div className="sticky flex flex-col items-start top-32 self-start z-10">
               {/* Dot indicator with original size */}
-              <motion.div 
-                className="h-2 w-2 absolute left-0 top-2 rounded-full bg-black dark:bg-white z-20"
-                animate={{ 
+              <motion.div
+                className="h-2.5 w-2.5 absolute left-0 top-2 rounded-full bg-orange-400 dark:bg-orange-300 z-20"
+                animate={{
                   scale: inModal ? 1 : (activeIndex === index ? 1.5 : 1),
                   opacity: inModal ? 1 : (activeIndex === index ? 1 : 0.5)
                 }}
@@ -111,7 +111,7 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
             </div>
             <div className="relative pl-6 w-full">
               <div className="mb-3">
-                <h3 className="text-lg font-medium text-foreground">
+                <h3 className="text-base font-semibold text-foreground">
                   {item.title}
                 </h3>
                 {item.subtitle && (


### PR DESCRIPTION
## Summary
- extend active line to end of timeline
- tidy up timeline visuals
- ensure last dot sticks on mobile with extra padding

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684407f01ccc8330b02de10d5653b766