### PR TITLE
Redesign mobile navigation and improve mobile header UX

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,5 +1,5 @@
 import  ThemeToggle  from '@/components/utility/theme-toggle'
-import { PanelLeft } from 'lucide-react'
+import { Menu } from 'lucide-react'
 
 import Link from 'next/link';
 import { JSX, SVGProps } from 'react'
@@ -38,10 +38,7 @@ export default function Header() {
     <header className="fixed inset-x-0 top-0 z-50 bg-background/75 py-6 backdrop-blur-sm">
       <nav className="container flex max-w-3xl items-center justify-between">
         <div className="md:hidden">
-          <Button size='sm'
-      variant='ghost' className="text-foreground" aria-label="Toggle navigation">
-            <PanelLeft className="size-5" />
-          </Button>
+          <ThemeToggle />
         </div>
         <div className="hidden md:block">
           <a key={logo.name} href={logo.href} className='text-foreground'>
@@ -66,8 +63,14 @@ export default function Header() {
             <Link href="mailto:info@pascalheue.dev?subject=Kontakt%20Anfrage%20Website&body=Hey%2C%20">Kontakt</Link>
           </li>
         </ul>
-        <div>
-          <ThemeToggle />
+        <div className="flex items-center gap-1">
+          <Button size='sm' variant='ghost' className="text-foreground md:hidden" aria-label="Toggle navigation">
+            <Menu className="size-5" />
+            <span className="text-xs font-medium">Menü</span>
+          </Button>
+          <div className='hidden md:block'>
+            <ThemeToggle />
+          </div>
         </div>
       </nav>
     </header>

--- a/components/layout/mobile-navigation.tsx
+++ b/components/layout/mobile-navigation.tsx
@@ -1,31 +1,84 @@
 'use client'
 
 import React from 'react'
-import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet"
-
 import Link from 'next/link'
-
+import { usePathname } from 'next/navigation'
+import { Mail, Newspaper, FolderKanban, ArrowUpRight } from 'lucide-react'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { cn } from '@/lib/utils'
 
 interface MobileNavigationProps {
-  open: boolean;
-  setOpen: (open: boolean) => void;
+  open: boolean
+  setOpen: (open: boolean) => void
 }
 
+const navItems = [
+  {
+    href: '/projects',
+    label: 'Projekte',
+    icon: FolderKanban,
+  },
+  {
+    href: '/posts',
+    label: 'Blog',
+    icon: Newspaper,
+  },
+  {
+    href: 'mailto:info@pascalheue.dev?subject=Kontakt%20Anfrage%20Website&body=Hey%2C%20',
+    label: 'Kontakt',
+    icon: Mail,
+  },
+]
+
 export default function MobileNavigation({ open, setOpen }: MobileNavigationProps) {
+  const pathname = usePathname()
+
   return (
-    <div className="md:hidden">
+    <div className='md:hidden'>
       <Sheet open={open} onOpenChange={setOpen}>
-        
         <SheetContent
-          side="left"
-          className="w-10 pt-16 bg-gray-100 dark:bg-gray-800 bg-opacity-40 dark:bg-opacity-40 backdrop-blur-sm border-r border-r-white/10 dark:border-r-white/10"
+          side='bottom'
+          className='h-auto rounded-t-3xl border-white/15 bg-background/92 px-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-8 backdrop-blur-xl'
         >
-          <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
-          <nav className="flex flex-col h-full justify-end items-center pb-7 space-y-10">
-            <Link href="mailto:info@pascalheue.dev?subject=Kontakt%20Anfrage%20Website&body=Hey%2C%20" className="-rotate-90 text-sm font-light text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors">Kontakt</Link>
-            <Link href="/posts" className="-rotate-90 text-sm font-light text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors">Blog</Link>
-            <Link href="/projects" className="-rotate-90 text-sm font-light text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors">Projekte</Link>
+          <SheetTitle className='sr-only'>Navigation Menü</SheetTitle>
+
+          <div className='mx-auto mb-5 h-1.5 w-14 rounded-full bg-muted-foreground/40' />
+
+          <nav className='grid grid-cols-3 gap-2'>
+            {navItems.map(({ href, label, icon: Icon }) => {
+              const isActive = href.startsWith('/') && pathname.startsWith(href)
+
+              return (
+                <Link
+                  key={label}
+                  href={href}
+                  onClick={() => setOpen(false)}
+                  className={cn(
+                    'group rounded-2xl border p-3 transition-all',
+                    'border-white/10 bg-secondary/50 hover:border-primary/40 hover:bg-secondary',
+                    isActive && 'border-primary/50 bg-primary/10'
+                  )}
+                >
+                  <div className='mb-2 inline-flex rounded-lg bg-background/70 p-2'>
+                    <Icon className='size-4 text-foreground/90' />
+                  </div>
+                  <p className='text-sm font-medium text-foreground'>{label}</p>
+                </Link>
+              )
+            })}
           </nav>
+
+          <div className='mt-4 rounded-2xl border border-white/10 bg-secondary/30 p-3'>
+            <p className='text-xs text-muted-foreground'>Quick Access</p>
+            <Link
+              href='/'
+              onClick={() => setOpen(false)}
+              className='mt-2 inline-flex items-center gap-1 text-sm text-foreground underline underline-offset-4'
+            >
+              Startseite
+              <ArrowUpRight className='size-3.5' />
+            </Link>
+          </div>
         </SheetContent>
       </Sheet>
     </div>


### PR DESCRIPTION
### Motivation
- Improve mobile usability by replacing the rotated vertical navigation with a more readable, thumb-friendly pattern that matches the site’s clean, dark design language. 
- Make the theme control and navigation affordances clearer and easier to discover on small screens.

### Description
- Replaced the left-rotated sheet with a bottom-sheet dock by updating `components/layout/mobile-navigation.tsx` to use `SheetContent side='bottom'` and new rounded, blurred styling. 
- Implemented card-like navigation targets with icons and active-state styling for `Projekte`, `Blog` and `Kontakt`, added a small `Quick Access` block (Startseite) and used `usePathname` + `cn` for active classes. 
- Swapped mobile control placement in `components/layout/header.tsx` so the `ThemeToggle` is shown on the left and the navigation trigger (now a `Menu` icon with a `Menü` label) is on the right for better discoverability. 
- Added/updated icon imports (`lucide-react`) and small UI refinements to align touch target sizes and spacing with WCAG guidance.

### Testing
- Ran linting with `npm run lint`, which completed successfully with no reported errors. 
- Attempted to run a dev server and capture a mobile screenshot via Playwright, but Playwright browser binaries were not available in the environment so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90e1d50f48330b9b2f68ad305189c)