### PR TITLE
Mobile navigation redesign: bottom-dock pattern and mobile Theme/Nav swap

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,11 +1,9 @@
-import  ThemeToggle  from '@/components/utility/theme-toggle'
+import ThemeToggle from '@/components/utility/theme-toggle'
 import { PanelLeft } from 'lucide-react'
 
-import Link from 'next/link';
+import Link from 'next/link'
 import { JSX, SVGProps } from 'react'
-import { Button } from '@/components/ui/button';
-
-
+import { Button } from '@/components/ui/button'
 
 const logo = {
   name: 'Logo',
@@ -31,43 +29,42 @@ const logo = {
   )
 }
 
-
-
 export default function Header() {
   return (
     <header className="fixed inset-x-0 top-0 z-50 bg-background/75 py-6 backdrop-blur-sm">
-      <nav className="container flex max-w-3xl items-center justify-between">
+      <nav className="container relative flex max-w-3xl items-center justify-between">
         <div className="md:hidden">
-          <Button size='sm'
-      variant='ghost' className="text-foreground" aria-label="Toggle navigation">
-            <PanelLeft className="size-5" />
-          </Button>
+          <ThemeToggle />
         </div>
+
         <div className="hidden md:block">
           <a key={logo.name} href={logo.href} className='text-foreground'>
             <span className='sr-only'>{logo.name}</span>
             <logo.icon aria-hidden='true' className='h-8 w-8' />
           </a>
         </div>
-        <div className="md:hidden absolute left-1/2 transform -translate-x-1/2">
+
+        <div className="md:hidden absolute left-1/2 -translate-x-1/2 transform">
           <a key={logo.name} href={logo.href} className='text-foreground'>
             <span className='sr-only'>{logo.name}</span>
             <logo.icon aria-hidden='true' className='h-8 w-8' />
           </a>
         </div>
+
         <ul className="hidden md:flex items-center gap-6 text-sm font-light text-muted-foreground sm:gap-10">
-          <li className="transition-colors hover:text-foreground">
-            <Link href="/projects">Projekte</Link>
-          </li>
-          <li className="transition-colors hover:text-foreground">
-            <Link href="/posts">Blog</Link>
-          </li>
-          <li className="transition-colors hover:text-foreground">
-            <Link href="mailto:info@pascalheue.dev?subject=Kontakt%20Anfrage%20Website&body=Hey%2C%20">Kontakt</Link>
-          </li>
+          <li className="transition-colors hover:text-foreground"><Link href="/projects">Projekte</Link></li>
+          <li className="transition-colors hover:text-foreground"><Link href="/posts">Blog</Link></li>
+          <li className="transition-colors hover:text-foreground"><Link href="mailto:info@pascalheue.dev?subject=Kontakt%20Anfrage%20Website&body=Hey%2C%20">Kontakt</Link></li>
         </ul>
-        <div>
+
+        <div className="hidden md:block">
           <ThemeToggle />
+        </div>
+
+        <div className="md:hidden">
+          <Button size='sm' variant='ghost' className="text-foreground" aria-label="Toggle navigation">
+            <PanelLeft className="size-5" />
+          </Button>
         </div>
       </nav>
     </header>

--- a/components/layout/mobile-navigation.tsx
+++ b/components/layout/mobile-navigation.tsx
@@ -1,33 +1,68 @@
 'use client'
 
 import React from 'react'
-import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet"
-
 import Link from 'next/link'
-
+import { usePathname } from 'next/navigation'
+import { Mail, Newspaper, BriefcaseBusiness, Palette } from 'lucide-react'
 
 interface MobileNavigationProps {
-  open: boolean;
-  setOpen: (open: boolean) => void;
+  open: boolean
+  setOpen: (open: boolean) => void
 }
 
+const navigationItems = [
+  { href: '/projects', label: 'Projekte', icon: BriefcaseBusiness },
+  { href: '/posts', label: 'Blog', icon: Newspaper },
+  { href: 'mailto:info@pascalheue.dev?subject=Kontakt%20Anfrage%20Website&body=Hey%2C%20', label: 'Kontakt', icon: Mail },
+]
+
 export default function MobileNavigation({ open, setOpen }: MobileNavigationProps) {
+  const pathname = usePathname()
+
   return (
-    <div className="md:hidden">
-      <Sheet open={open} onOpenChange={setOpen}>
-        
-        <SheetContent
-          side="left"
-          className="w-10 pt-16 bg-gray-100 dark:bg-gray-800 bg-opacity-40 dark:bg-opacity-40 backdrop-blur-sm border-r border-r-white/10 dark:border-r-white/10"
-        >
-          <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
-          <nav className="flex flex-col h-full justify-end items-center pb-7 space-y-10">
-            <Link href="mailto:info@pascalheue.dev?subject=Kontakt%20Anfrage%20Website&body=Hey%2C%20" className="-rotate-90 text-sm font-light text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors">Kontakt</Link>
-            <Link href="/posts" className="-rotate-90 text-sm font-light text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors">Blog</Link>
-            <Link href="/projects" className="-rotate-90 text-sm font-light text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors">Projekte</Link>
-          </nav>
-        </SheetContent>
-      </Sheet>
+    <div className="md:hidden pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center px-4">
+      <div className="pointer-events-auto w-full max-w-sm rounded-3xl border border-white/10 bg-background/75 p-2 shadow-2xl backdrop-blur-xl supports-[backdrop-filter]:bg-background/65">
+        <div className="grid grid-cols-[auto_1fr] items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setOpen(!open)}
+            aria-expanded={open}
+            aria-controls="mobile-nav-links"
+            className="group flex h-12 w-12 items-center justify-center rounded-2xl border border-white/15 bg-foreground/5 text-foreground transition hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400"
+          >
+            <Palette className="size-5 transition group-hover:scale-105" />
+            <span className="sr-only">Navigation ein- oder ausklappen</span>
+          </button>
+
+          <div
+            id="mobile-nav-links"
+            className={`grid overflow-hidden transition-all duration-300 ${open ? 'max-h-56 opacity-100' : 'max-h-12 opacity-95'}`}
+          >
+            <div className={`grid gap-2 ${open ? 'grid-cols-1' : 'grid-cols-3'}`}>
+              {navigationItems.map((item) => {
+                const isActive = item.href.startsWith('/') && pathname === item.href
+                const Icon = item.icon
+
+                return (
+                  <Link
+                    key={item.label}
+                    href={item.href}
+                    onClick={() => setOpen(false)}
+                    className={`flex items-center gap-3 rounded-2xl border px-4 py-3 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 ${
+                      isActive
+                        ? 'border-yellow-400/50 bg-yellow-400/10 text-foreground'
+                        : 'border-white/10 bg-foreground/5 text-muted-foreground hover:bg-foreground/10 hover:text-foreground'
+                    }`}
+                  >
+                    <Icon className="size-4 shrink-0" />
+                    <span className={open ? 'inline' : 'sr-only'}>{item.label}</span>
+                  </Link>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Die mobile Navigation wurde ergonomisch verbessert, weil das vorherige hochkant/rotierte Layout auf Touch-Geräten schlechter lesbar und weniger erreichbar war.
- Ziel ist ein kontext-erhaltendes, nicht-standardmäßiges Muster (kein Fullscreen-Overlay) das zur bestehenden Glas-/Blur-Designsprache passt.
- Der Theme-Toggle wurde auf Mobile mit dem Navigations-Trigger vertauscht, da Theme sekundär und Navigation primär ist.

### Description
- Ersetzt `components/layout/mobile-navigation.tsx`: statt rotiertem Side-Sheet gibt es jetzt ein bottom-docked, expandierbares Navigation-Widget mit kompakter und ausgeklappter Ansicht, Icon-First-Layout und sanften Übergängen.
- Navigation nutzt `usePathname` und Tabler/Lucide-Icons, zeigt aktive Zustände an und hat sichtbare Keyboard-Focus-Ringe für bessere Accessibility.
- Aktualisiert `components/layout/header.tsx`, sodass auf Mobile der `ThemeToggle` links und der Navigations-Trigger rechts sitzt, während Desktop-Header unverändert bleibt.
- Visuelle Details: frosted/glass Hintergrund, weiche Ränder, gelbe Accent-Focus-Farbe und Touch-optimierte Targets; bestehende Swipe-/Wrapper-Öffnen-Logik bleibt erhalten.

### Testing
- `npm run lint` wurde ausgeführt und ist erfolgreich durchgelaufen.
- `npm run build` wurde ausgeführt und schlägt fehl aufgrund von Google-Fonts / Turbopack Font-Resolution-Fehlern beim Herunterladen externer Fonts, was nicht durch die Nav-Änderungen verursacht wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90e1d50f48330b9b2f68ad305189c)